### PR TITLE
ID edits

### DIFF
--- a/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/Messages.properties
+++ b/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/Messages.properties
@@ -11,23 +11,23 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 CLIENT_WIZARD_PAGE_TITLE=Client API from OpenAPI Specification
-CLIENT_WIZARD_PAGE_DESCRIPTION=Generate a client API stub from an OpenAPI Specification
+CLIENT_WIZARD_PAGE_DESCRIPTION=Generate a client API stub from an OpenAPI Specification.
 
 SERVER_WIZARD_PAGE_TITLE=Server API from OpenAPI Specification
-SERVER_WIZARD_PAGE_DESCRIPTION=Generate a server API stub from an OpenAPI Specification
+SERVER_WIZARD_PAGE_DESCRIPTION=Generate a server API stub from an OpenAPI Specification.
 
 HTML_WIZARD_PAGE_TITLE=HTML from OpenAPI Specification
-HTML_WIZARD_PAGE_DESCRIPTION=Generate HTML documentation from an OpenAPI Specification
+HTML_WIZARD_PAGE_DESCRIPTION=Generate HTML documentation from an OpenAPI Specification.
 
 INFO_FILES_EXIST_TITLE=Generated code already exists
-INFO_FILES_EXIST_DESCRIPTION=Existing files may be overwritten.  Add filters to .openapi-generator-ignore to ensure desired files are not overwritten. Continue?
+INFO_FILES_EXIST_DESCRIPTION=Existing files might be overwritten. Add filters to .openapi-generator-ignore to ensure that the wanted files are not overwritten. Continue?
 
 INFO_OPENAPI_TITLE=OpenAPI Tools
-INFO_PROJECT_NOT_IMPORTED=The Codewind project is not currently in the workspace.  Import the project into the workspace and try again
-INFO_INVALID_SELECTION=Select a workspace project or an OpenAPI file from the Project or Package Explorer view or a Codewind project from the Codewind Explorer view
+INFO_PROJECT_NOT_IMPORTED=The Codewind project is not currently in the workspace. Import the project into the workspace and try again.
+INFO_INVALID_SELECTION=Select a workspace project or an OpenAPI file from the Project or Package Explorer view or a Codewind project from the Codewind Explorer view.
 
-WIZARD_PAGE_OUTPUT_FOLDER_TOOLTIP=The location of the generated files. A folder within the selected project
-WIZARD_PAGE_GENERATOR_TYPE_TOOLTIP=The generator name as used by the OpenAPI Generator's -g option
+WIZARD_PAGE_OUTPUT_FOLDER_TOOLTIP=The location of the generated files. A folder within the selected project.
+WIZARD_PAGE_GENERATOR_TYPE_TOOLTIP=The generator name as used by the OpenAPI Generator -g option
 
 WIZARD_PAGE_PROJECT=&Project:
 WIZARD_PAGE_SPECIFICATION=&OpenAPI Specification:
@@ -37,18 +37,18 @@ WIZARD_PAGE_GENERATOR_TYPE=&Generator name:
 WIZARD_PAGE_BROWSE_FILE=&Browse...
 WIZARD_PAGE_BROWSE_FOLDER=Bro&wse...
 
-WIZARD_PAGE_PROJECT_NOT_PROVIDED=Project must be provided
-WIZARD_PAGE_PROJECT_NOT_IMPORTED=The project must exist
-WIZARD_PAGE_PROJECT_NOT_ACCESSIBLE=The project is closed or is not writable
-WIZARD_PAGE_SELECT_SPEC=Select an OpenAPI Specification.  The file must be in the project
-WIZARD_PAGE_SELECT_OUTPUT_FOLDER=Select an output folder for the generated code
-WIZARD_PAGE_SELECT_LANGUAGE=Select a language
-WIZARD_PAGE_SELECT_GENERATOR_TYPE=Select a generator type
+WIZARD_PAGE_PROJECT_NOT_PROVIDED=The project must be provided.
+WIZARD_PAGE_PROJECT_NOT_IMPORTED=The project must exist.
+WIZARD_PAGE_PROJECT_NOT_ACCESSIBLE=The project is closed or is not writable.
+WIZARD_PAGE_SELECT_SPEC=Select an OpenAPI Specification. The file must be in the project.
+WIZARD_PAGE_SELECT_OUTPUT_FOLDER=Select an output folder for the generated code.
+WIZARD_PAGE_SELECT_LANGUAGE=Select a language.
+WIZARD_PAGE_SELECT_GENERATOR_TYPE=Select a generator type.
 
-BROWSE_DIALOG_MESSAGE_SELECT_SPEC=Select an OpenAPI Specification from the project
-BROWSE_DIALOG_TITLE_SELECT_SPEC=Select an OpenAPI Specification file
+BROWSE_DIALOG_MESSAGE_SELECT_SPEC=Select an OpenAPI Specification from the project.
+BROWSE_DIALOG_TITLE_SELECT_SPEC=Select an OpenAPI Specification file.
 
-BROWSE_DIALOG_MESSAGE_SELECT_FOLDER=Select an output folder for the generated files
-BROWSE_DIALOG_TITLE_SELECT_FOLDER=Select Folder
+BROWSE_DIALOG_MESSAGE_SELECT_FOLDER=Select an output folder for the generated files.
+BROWSE_DIALOG_TITLE_SELECT_FOLDER=Select a folder.
 
-BROWSE_DIALOG_NO_CHILD_FOLDERS=There are no child folders in this project.  The stub will be generated into the project root
+BROWSE_DIALOG_NO_CHILD_FOLDERS=This project does not contain child folders. The stub will be generated into the project root.


### PR DESCRIPTION
- Is line 38 supposed to have the `&` symbol inside the middle of the word `Browse`? Or is it supposed to match line 37?
- Only include one space after a period.
- For lines 40 to 46, will the user have enough info to go on to do what these messages tell them? For example, when they read, "The project must exist." will they know how to create the project so that it exists?